### PR TITLE
Update plugin to work with latest JOSM API (>= 10273)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -16,7 +16,7 @@
     <!-- enter the SVN commit message -->
     <property name="commit.message" value="Changed the constructor signature of the plugin main class"/>
     <!-- enter the *lowest* JOSM version this plugin is currently compatible with -->
-    <property name="plugin.main.version" value="8906"/>
+    <property name="plugin.main.version" value="10273"/>
 
     <property name="plugin.author" value="Ian Dees, Seth Fitzsimmons"/>
     <property name="plugin.class" value="org.openstreetmap.josm.plugins.fieldpapers.FieldPapersPlugin"/>

--- a/src/org/openstreetmap/josm/plugins/fieldpapers/FieldPapersAddLayerAction.java
+++ b/src/org/openstreetmap/josm/plugins/fieldpapers/FieldPapersAddLayerAction.java
@@ -4,13 +4,13 @@ import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.data.coor.LatLon;
-import org.openstreetmap.josm.data.ViewportData;
 
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
-import javax.swing.*;
+import javax.swing.JOptionPane;
+
 import java.awt.event.ActionEvent;
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,7 +64,7 @@ public class FieldPapersAddLayerAction extends JosmAction {
             Bounds b = new Bounds(new LatLon(south, west), new LatLon(north, east));
 
             FieldPapersLayer wpl = new FieldPapersLayer(id, tileUrl, b, minZoom, maxZoom);
-            Main.main.addLayer(wpl, (ViewportData) null);
+            Main.getLayerManager().addLayer(wpl);
 
         } catch (IOException ex) {
             ex.printStackTrace();


### PR DESCRIPTION
Similar to #2. This allows the plugin to work with the newest JOSM versions.

I also [forked this project](https://github.com/floscher/josm-fieldpapers) and [released a version over there as `v0.4.2`](https://github.com/floscher/josm-fieldpapers/releases/tag/v0.4.2) containing this fix (otherwise identical to `v0.4.1`). I intend this as a temporary workaround to provide the users of the plugin with a working version of the plugin as soon as possible. The version in my repository is [currently distributed via the JOSM plugin update mechanism](https://josm.openstreetmap.de/wiki/PluginsSource?action=diff&version=192&old_version=191), but feel free to change that back, as soon as the version over here is fixed.

If you are interested, you are welcome to also pull a056a750078ba0f9b7f76d2694aac00ff7fde98b...3964dc1391404abc24902929b2977fa5d3811e71 in which I added a Gradle build script, which is automatically used by Travis CI to build the project and release a *.jar file when a release is tagged.