### PR TITLE
Update references to project location, the Gradle JOSM plugin and the JOSM version to compile against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ deploy:
       jdk: openjdk8
       repo: iandees/josm-fieldpapers
   - provider: releases
+    skip_cleanup: true
     api-key: "$GH_TOKEN"
     file:
       - build/dist/fieldpapers.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ jdk:
 - openjdk8
 - oraclejdk8
 - oraclejdk9
-script: ./gradlew build compileMinJosmVersion && cp -T `find build/libs/*.jar | head -1` "build/libs/fieldpapers.jar"
+script: ./gradlew build compileMinJosmVersion
 deploy:
   provider: releases
   api-key:
     secure: GUDz8pgKvi5M6m4oCMJoKqKT3GjU42PYTF97ASRaPjxVTXH0kETdmV0zADZuzITo5X5uALozP3pRjrtnnDFMmyyo+KIhhNplKr7T5aLJQMwI+bLT+ioseRlxqxAHPILf9qZKKbJKEsKAOEQ8N8fDxI5oyivXICT15LLjrCVS6Z8=
-  file: build/libs/fieldpapers.jar
+  file: build/dist/fieldpapers.jar
   on:
     tags: true
     jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,24 @@ jdk:
 - oraclejdk9
 script: ./gradlew build compileMinJosmVersion
 deploy:
-  provider: releases
-  api-key:
-    secure: GUDz8pgKvi5M6m4oCMJoKqKT3GjU42PYTF97ASRaPjxVTXH0kETdmV0zADZuzITo5X5uALozP3pRjrtnnDFMmyyo+KIhhNplKr7T5aLJQMwI+bLT+ioseRlxqxAHPILf9qZKKbJKEsKAOEQ8N8fDxI5oyivXICT15LLjrCVS6Z8=
-  file: build/dist/fieldpapers.jar
-  on:
-    tags: true
-    jdk: openjdk8
-    repo: iandees/josm-fieldpapers
+  - provider: releases
+    api-key:
+      secure: GUDz8pgKvi5M6m4oCMJoKqKT3GjU42PYTF97ASRaPjxVTXH0kETdmV0zADZuzITo5X5uALozP3pRjrtnnDFMmyyo+KIhhNplKr7T5aLJQMwI+bLT+ioseRlxqxAHPILf9qZKKbJKEsKAOEQ8N8fDxI5oyivXICT15LLjrCVS6Z8=
+    file: build/dist/fieldpapers.jar
+    on:
+      tags: true
+      jdk: openjdk8
+      repo: iandees/josm-fieldpapers
+  - provider: releases
+    api-key: "$GH_TOKEN"
+    file:
+      - build/dist/fieldpapers.jar
+      - build/tmp/jar/MANIFEST.MF
+    on:
+      tags: true
+      jdk: openjdk8
+      repo: floscher/josm-fieldpapers
+      condition: $DEPLOY_GITHUB_RELEASES = true
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,14 @@ deploy:
   - provider: releases
     api-key:
       secure: GUDz8pgKvi5M6m4oCMJoKqKT3GjU42PYTF97ASRaPjxVTXH0kETdmV0zADZuzITo5X5uALozP3pRjrtnnDFMmyyo+KIhhNplKr7T5aLJQMwI+bLT+ioseRlxqxAHPILf9qZKKbJKEsKAOEQ8N8fDxI5oyivXICT15LLjrCVS6Z8=
-    file: build/dist/fieldpapers.jar
-    on:
-      tags: true
-      jdk: openjdk8
-      repo: iandees/josm-fieldpapers
-  - provider: releases
     skip_cleanup: true
-    api-key: "$GH_TOKEN"
     file:
       - build/dist/fieldpapers.jar
       - build/tmp/jar/MANIFEST.MF
     on:
       tags: true
       jdk: openjdk8
-      repo: floscher/josm-fieldpapers
-      condition: $DEPLOY_GITHUB_RELEASES = true
+      repo: fieldpapers/josm-fieldpapers
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 A plugin for displaying tiled, scanned maps from fieldpapers.org.
 
-[![Travis CI build status](https://img.shields.io/travis/floscher/josm-fieldpapers/master.svg?style=flat-square)](https://travis-ci.org/floscher/josm-fieldpapers)
-[![latest release](https://img.shields.io/github/release/floscher/josm-fieldpapers.svg?style=flat-square)](https://github.com/floscher/josm-fieldpapers/releases/latest)
-![download count of latest release](https://img.shields.io/github/downloads/floscher/josm-fieldpapers/latest/total.svg?style=flat-square)
+[![Travis CI build status](https://img.shields.io/travis/fieldpapers/josm-fieldpapers/master.svg?style=flat-square)](https://travis-ci.org/fieldpapers/josm-fieldpapers)
+[![latest release](https://img.shields.io/github/release/fieldpapers/josm-fieldpapers.svg?style=flat-square)](https://github.com/fieldpapers/josm-fieldpapers/releases/latest)
+![download count of latest release](https://img.shields.io/github/downloads/fieldpapers/josm-fieldpapers/latest/fieldpapers.jar.svg?style=flat-square)
 
 Adapted by Ian Dees <ian.dees@gmail.com> from a plugin written by
 Frederik Ramm <frederik@remote.org>, based on SlippyMap plugin work

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 A plugin for displaying tiled, scanned maps from fieldpapers.org.
 
-![Travis CI build status](https://img.shields.io/travis/iandees/josm-fieldpapers/master.svg?style=flat-square)
-![latest release](https://img.shields.io/github/release/iandees/josm-fieldpapers.svg?style=flat-square)
-![download count of latest release](https://img.shields.io/github/downloads/iandees/josm-fieldpapers/latest/total.svg?style=flat-square)
+[![Travis CI build status](https://img.shields.io/travis/floscher/josm-fieldpapers/master.svg?style=flat-square)](https://travis-ci.org/floscher/josm-fieldpapers)
+[![latest release](https://img.shields.io/github/release/floscher/josm-fieldpapers.svg?style=flat-square)](https://github.com/floscher/josm-fieldpapers/releases/latest)
+![download count of latest release](https://img.shields.io/github/downloads/floscher/josm-fieldpapers/latest/total.svg?style=flat-square)
 
 Adapted by Ian Dees <ian.dees@gmail.com> from a plugin written by
 Frederik Ramm <frederik@remote.org>, based on SlippyMap plugin work

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "org.openstreetmap.josm.gradle.plugin" version "0.1.9"
+  id "org.openstreetmap.josm.gradle.plugin" version "0.1.10"
   id 'eclipse'
   id 'idea'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ sourceSets {
 }
 
 archivesBaseName = 'fieldpapers'
+josm.manifest {
+  oldVersionDownloadLink 10273, 'v0.4.2', new URL('https://github.com/floscher/josm-fieldpapers/releases/download/v0.4.2/fieldpapers.jar')
+}
 
 eclipse.project.name = 'JOSM-fieldpapers'
 eclipseClasspath.dependsOn cleanEclipseClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-  id "org.openstreetmap.josm.gradle.plugin" version "0.1.6"
+  id "org.openstreetmap.josm.gradle.plugin" version "0.1.9"
+  id 'eclipse'
+  id 'idea'
 }
-apply plugin: 'eclipse'
-apply plugin: 'idea'
 apply from: 'gradle/version-functions.gradle'
 
 sourceCompatibility = '1.8'
@@ -22,9 +22,7 @@ sourceSets {
   }
 }
 
-josm {
-  jarName = 'fieldpapers.jar'
-}
+archivesBaseName = 'fieldpapers'
 
 eclipse.project.name = 'JOSM-fieldpapers'
 eclipseClasspath.dependsOn cleanEclipseClasspath

--- a/config/josm/preferences.xml
+++ b/config/josm/preferences.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<preferences xmlns="http://josm.openstreetmap.de/preferences-1.0">
-  <!-- This set of preferences is used by JOSM when launched from `gradlew runJosm`. -->
-  <list key='plugins'>
-    <entry value='fieldpapers'/>
-  </list>
-  <tag key='pluginmanager.time-based-update.policy' value='never'/>
-  <tag key='pluginmanager.version-based-update.policy' value='never'/>
-</preferences>

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ plugin.main.version=12643
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=12712
+plugin.compile.version=13053


### PR DESCRIPTION
* the `gradle-josm-plugin` has been bumped to version `v0.1.10` (no longer requires the JOSM config file and you no longer need to rename the distribution file in Travis CI)
* the JOSM version to compile against has been bumped to `13053`
* The README and the Travis build have been updated to point to `fieldpapers/josm-fieldpapers` instead of `iandees/josm-fieldpapers`