### PR TITLE
Push translatable strings to transifex.com when building the master branch on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,27 @@ deploy:
       jdk: openjdk8
       repo: fieldpapers/josm-fieldpapers
 
+jobs:
+  include:
+    - stage: i18n
+      language: python
+      python: "3.5"
+      install: pip install git+https://github.com/transifex/transifex-client.git@a706ba0cb910e66e852010bcd742221363c7e8be#egg=transifex-client
+      script: |
+        if [ ! -z "$TRANSIFEX_TOKEN" ]; then
+          ./gradlew generatePot
+          tx --token="$TRANSIFEX_TOKEN" --force-save --no-interactive init
+          git checkout HEAD .tx/config
+          tx push -s --no-interactive
+        fi
+
+stages:
+  - test
+  - name: i18n
+    if: type = push AND branch = master
+
 matrix:
   fast_finish: true
   allow_failures:
   - jdk: oraclejdk9
+  - language: python

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[josm.josm-plugin_fieldpapers]
+file_filter = src/main/po/<lang>.po
+source_file = build/i18n/josm-plugin_fieldpapers.pot
+source_lang = en
+type = PO

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "org.openstreetmap.josm.gradle.plugin" version "0.1.10"
+  id "org.openstreetmap.josm" version "0.3.1"
   id 'eclipse'
   id 'idea'
 }
@@ -23,8 +23,13 @@ sourceSets {
 }
 
 archivesBaseName = 'fieldpapers'
-josm.manifest {
-  oldVersionDownloadLink 10273, 'v0.4.2', new URL('https://github.com/floscher/josm-fieldpapers/releases/download/v0.4.2/fieldpapers.jar')
+josm {
+  i18n {
+      pathTransformer = getGithubPathTransformer('fieldpapers/josm-fieldpapers')
+  }
+  manifest {
+    oldVersionDownloadLink 10273, 'v0.4.2', new URL('https://github.com/floscher/josm-fieldpapers/releases/download/v0.4.2/fieldpapers.jar')
+  }
 }
 
 eclipse.project.name = 'JOSM-fieldpapers'

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ plugin.main.version=12643
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=13053
+plugin.compile.version=13265


### PR DESCRIPTION
This requires the environment variable `$TRANSIFEX_TOKEN` to be set to an API token for transifex.com. If that variable is not set, the strings are simply not uploaded.

In this commit the version of JOSM and the gradle-josm-plugin is also bumped to the latest version.