### PR TITLE
Move menu bar entry to imagery menu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "org.openstreetmap.josm" version "0.3.1"
+  id "org.openstreetmap.josm" version "0.3.4"
   id 'eclipse'
   id 'idea'
 }

--- a/src/org/openstreetmap/josm/plugins/fieldpapers/FieldPapersAddLayerAction.java
+++ b/src/org/openstreetmap/josm/plugins/fieldpapers/FieldPapersAddLayerAction.java
@@ -33,7 +33,7 @@ import org.openstreetmap.josm.tools.Utils;
 public class FieldPapersAddLayerAction extends JosmAction {
 
     public FieldPapersAddLayerAction() {
-        super(tr("Scanned Map..."), "fieldpapers",
+        super(tr("FieldPapers snapshot"), "fieldpapers",
             tr("Display a map that was previously scanned and uploaded to fieldpapers.org"), null, false);
     }
 

--- a/src/org/openstreetmap/josm/plugins/fieldpapers/FieldPapersPlugin.java
+++ b/src/org/openstreetmap/josm/plugins/fieldpapers/FieldPapersPlugin.java
@@ -1,15 +1,8 @@
 package org.openstreetmap.josm.plugins.fieldpapers;
 
-import static org.openstreetmap.josm.gui.help.HelpUtil.ht;
-import static org.openstreetmap.josm.tools.I18n.tr;
-
-import java.awt.event.KeyEvent;
-
-import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
 import org.openstreetmap.josm.gui.MainApplication;
-import org.openstreetmap.josm.gui.MainMenu;
 import org.openstreetmap.josm.plugins.Plugin;
 import org.openstreetmap.josm.plugins.PluginInformation;
 
@@ -20,14 +13,9 @@ import org.openstreetmap.josm.plugins.PluginInformation;
  * @author Frederik Ramm <frederik@remote.org>
  *
  */
-public class FieldPapersPlugin extends Plugin
-{
-    public FieldPapersPlugin(PluginInformation info)
-    {
+public class FieldPapersPlugin extends Plugin {
+    public FieldPapersPlugin(PluginInformation info) {
         super(info);
-
-        MainMenu menu = MainApplication.getMenu();
-        JMenu fpMenu = menu.addMenu("Field Papers", tr("Field Papers"), KeyEvent.VK_K, menu.getDefaultMenuPos(), ht("/Plugin/FieldPapers"));
-        fpMenu.add(new JMenuItem(new FieldPapersAddLayerAction()));
+        MainApplication.getMenu().imageryMenu.add(new JMenuItem(new FieldPapersAddLayerAction()));
     }
 }


### PR DESCRIPTION
Instead of being at "Field Papers › Scanned map ...", the entry can now be found at "Imagery › FieldPapers snapshot".